### PR TITLE
Auth with cookies

### DIFF
--- a/cmd/api-server/auth/handler.go
+++ b/cmd/api-server/auth/handler.go
@@ -65,6 +65,8 @@ func (h *Handler) Login(c *gin.Context) {
 		log.Println("Failed to update last login at")
 	}
 
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie("auth", jwt, int(ttl.Seconds()), "/", h.Config.FrontendDomain, h.Config.CookieSecure, true)
 	c.JSON(http.StatusOK, gin.H{"token": jwt})
 }
 

--- a/cmd/api-server/auth/handler_test.go
+++ b/cmd/api-server/auth/handler_test.go
@@ -143,7 +143,7 @@ func TestHandler_Me(t *testing.T) {
 	// Create a request with correct token
 	req, _ := http.NewRequest("GET", "/auth/me", nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -183,7 +183,7 @@ func TestHandler_Me(t *testing.T) {
 
 	req, _ = http.NewRequest("GET", "/auth/me", nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -229,7 +229,7 @@ func TestHandler_ChangePassword(t *testing.T) {
 
 	req, _ := http.NewRequest("PATCH", "/auth/change-password", bytes.NewBuffer(jsonData))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -253,7 +253,7 @@ func TestHandler_ChangePassword(t *testing.T) {
 	jsonData, _ = json.Marshal(changePasswordRequest)
 	req, _ = http.NewRequest("PATCH", "/auth/change-password", bytes.NewBuffer(jsonData))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -269,7 +269,7 @@ func TestHandler_ChangePassword(t *testing.T) {
 	jsonData, _ = json.Marshal(changePasswordRequest)
 	req, _ = http.NewRequest("PATCH", "/auth/change-password", bytes.NewBuffer(jsonData))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -281,7 +281,7 @@ func TestHandler_ChangePassword(t *testing.T) {
 	jsonData, _ = json.Marshal(changePasswordRequest)
 	req, _ = http.NewRequest("PATCH", "/auth/change-password", bytes.NewBuffer(jsonData))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)

--- a/cmd/api-server/auth/middleware_test.go
+++ b/cmd/api-server/auth/middleware_test.go
@@ -47,7 +47,7 @@ func TestCheckCurrentUserValidToken(t *testing.T) {
 
 	// Create a request with an invalid Authorization header
 	req, _ := http.NewRequest("GET", "/test", nil)
-	req.Header.Set("Authorization", "Bearer invalid-token")
+	req.AddCookie(&http.Cookie{Name: "auth", Value: "invalid-token"})
 
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -64,7 +64,7 @@ func TestCheckCurrentUserValidToken(t *testing.T) {
 
 	// Create a request with an invalid format on Authorization header
 	req, _ = http.NewRequest("GET", "/test", nil)
-	req.Header.Set("Authorization", "invalid-token")
+	req.AddCookie(&http.Cookie{Name: "auth", Value: ""})
 
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -74,6 +74,7 @@ func TestCheckCurrentUserValidToken(t *testing.T) {
 	// Create a request with an invalid format on Authorization header
 	req, _ = http.NewRequest("GET", "/test", nil)
 	req.Header.Set("Authorization", "InvalidFormat invalid-token")
+	req.AddCookie(&http.Cookie{Name: "auth", Value: "InvalidFormat invalid-token"})
 
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -88,7 +89,7 @@ func TestCheckCurrentUserValidToken(t *testing.T) {
 	token, err := GenerateToken(1*time.Hour, payload, config.JWTSecret)
 	require.NoError(t, err)
 	req, _ = http.NewRequest("GET", "/test", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -100,11 +101,10 @@ func TestCheckCurrentUserValidToken(t *testing.T) {
 	token, err = GenerateToken(1*time.Hour, payload, config.JWTSecret)
 	require.NoError(t, err)
 	req, _ = http.NewRequest("GET", "/test", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code, "(valid token) should return 200 OK")
-
 }

--- a/cmd/api-server/config/config.go
+++ b/cmd/api-server/config/config.go
@@ -10,4 +10,7 @@ type Config struct {
 	AESStorageStrategy string `env:"AES_STORAGE_STRATEGY"`
 	AuthServiceURL     string `env:"AUTH_SERVICE_URL"`
 	AuthStrategySystem string `env:"AUTH_STRATEGY_SYSTEM"`
+	FrontendDomain     string `env:"FRONTEND_DOMAIN"`
+	CookieSecure       bool   `env:"COOKIE_SECURE"`
+	CorsOrigins        string `env:"CORS_ORIGINS"`
 }

--- a/cmd/api-server/middlewares/auth.go
+++ b/cmd/api-server/middlewares/auth.go
@@ -2,7 +2,6 @@ package middlewares
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/coffeenights/conure/cmd/api-server/database"
 	"github.com/gin-gonic/gin"
@@ -13,16 +12,21 @@ import (
 
 func CheckAuthenticatedUser(config *apiConfig.Config, mongo *database.MongoDB) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		authHeader := c.GetHeader("Authorization")
-		if authHeader == "" {
+		authToken, err := c.Cookie("auth")
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error": auth.ErrUnauthorized.Error(),
+			})
+			return
+		}
+		if authToken == "" {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
 				"error": auth.ErrUnauthorized.Error(),
 			})
 			return
 		}
 
-		token := strings.Split(authHeader, " ")
-		err := validateSignature(token, config)
+		_, err = auth.ValidateToken(authToken, config.JWTSecret)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
 				"error": err.Error(),
@@ -30,7 +34,7 @@ func CheckAuthenticatedUser(config *apiConfig.Config, mongo *database.MongoDB) g
 			return
 		}
 
-		user, err := ValidateUser(token[1], config, mongo)
+		user, err := ValidateUser(authToken, config, mongo)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
 				"error": err.Error(),
@@ -40,21 +44,4 @@ func CheckAuthenticatedUser(config *apiConfig.Config, mongo *database.MongoDB) g
 		c.Set("currentUser", user)
 		c.Next()
 	}
-}
-
-func validateSignature(token []string, config *apiConfig.Config) error {
-	if len(token) != 2 {
-		return auth.ErrUnauthorized
-	}
-
-	if token[0] != "Bearer" {
-		return auth.ErrUnauthorized
-	}
-
-	// validate the token signature
-	_, err := auth.ValidateToken(token[1], config.JWTSecret)
-	if err != nil {
-		return auth.ErrUnauthorized
-	}
-	return nil
 }

--- a/cmd/api-server/routes/groups.go
+++ b/cmd/api-server/routes/groups.go
@@ -25,7 +25,7 @@ func GenerateRouter() *gin.Engine {
 	}
 
 	router := gin.New()
-	router.Use(gin.Logger(), gin.Recovery(), cors.Default())
+	router.Use(gin.Logger(), gin.Recovery(), getCorsMiddleware(conf.CorsOrigins))
 	appHandler := apps.NewApiHandler()
 	authHandler := auth.NewAuthHandler(conf, mongo)
 	variablesHandler := variables.NewVariablesHandler(conf, mongo, keyStorage)
@@ -33,4 +33,13 @@ func GenerateRouter() *gin.Engine {
 	auth.GenerateRoutes("/auth", router, authHandler)
 	variables.GenerateRoutes("/variables", router, variablesHandler)
 	return router
+}
+
+func getCorsMiddleware(origins string) gin.HandlerFunc {
+	return cors.New(cors.Config{
+		AllowOrigins:     []string{origins},
+		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization"},
+		AllowCredentials: true,
+	})
 }

--- a/cmd/api-server/variables/handler_test.go
+++ b/cmd/api-server/variables/handler_test.go
@@ -84,7 +84,7 @@ func TestHandler_ListOrganizationVariables(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/variables/"+orgID.Hex(), nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -98,7 +98,7 @@ func TestHandler_ListOrganizationVariables(t *testing.T) {
 
 	req, _ = http.NewRequest("GET", "/variables/fakeOrg", nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -108,7 +108,7 @@ func TestHandler_ListOrganizationVariables(t *testing.T) {
 
 	req, _ = http.NewRequest("GET", "/variables/"+primitive.NewObjectID().Hex(), nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -189,7 +189,7 @@ func TestHandler_ListEnvironmentVariables(t *testing.T) {
 	url := fmt.Sprintf(urlFormat, orgID1.Hex(), app1.Hex(), env1)
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -204,7 +204,7 @@ func TestHandler_ListEnvironmentVariables(t *testing.T) {
 	fakeURL := fmt.Sprintf(urlFormat, orgID1.Hex(), app1.Hex(), "fakeEnv")
 	req, _ = http.NewRequest("GET", fakeURL, nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -225,7 +225,7 @@ func TestHandler_ListEnvironmentVariables(t *testing.T) {
 	fakeURL = fmt.Sprintf(urlFormat, orgID1.Hex(), "fakeApp", env1)
 	req, _ = http.NewRequest("GET", fakeURL, nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -236,7 +236,7 @@ func TestHandler_ListEnvironmentVariables(t *testing.T) {
 	fakeURL = fmt.Sprintf(urlFormat, "fakeOrg", primitive.NewObjectID().Hex(), env1)
 	req, _ = http.NewRequest("GET", fakeURL, nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -247,7 +247,7 @@ func TestHandler_ListEnvironmentVariables(t *testing.T) {
 	fakeURL = fmt.Sprintf(urlFormat, orgID1.Hex(), primitive.NewObjectID().Hex(), env1)
 	req, _ = http.NewRequest("GET", fakeURL, nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -322,7 +322,7 @@ func TestHandler_ListComponentVariables(t *testing.T) {
 	url := fmt.Sprintf(urlFormat, orgID1.Hex(), app1.Hex(), env1, comp1.Hex())
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -337,7 +337,7 @@ func TestHandler_ListComponentVariables(t *testing.T) {
 	fakeURL := fmt.Sprintf(urlFormat, orgID1.Hex(), app1.Hex(), env1, primitive.NewObjectID().Hex())
 	req, _ = http.NewRequest("GET", fakeURL, nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -349,7 +349,7 @@ func TestHandler_ListComponentVariables(t *testing.T) {
 	fakeURL = fmt.Sprintf(urlFormat, orgID1.Hex(), app1.Hex(), env1, "fakeComp")
 	req, _ = http.NewRequest("GET", fakeURL, nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -360,7 +360,7 @@ func TestHandler_ListComponentVariables(t *testing.T) {
 	fakeURL = fmt.Sprintf(urlFormat, "fakeOrg", app1.Hex(), env1, primitive.NewObjectID().Hex())
 	req, _ = http.NewRequest("GET", fakeURL, nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -380,7 +380,7 @@ func TestHandler_ListComponentVariables(t *testing.T) {
 	fakeURL = fmt.Sprintf(urlFormat, orgID1.Hex(), "fakeApp", env1, comp1.Hex())
 	req, _ = http.NewRequest("GET", fakeURL, nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -391,7 +391,7 @@ func TestHandler_ListComponentVariables(t *testing.T) {
 	fakeURL = fmt.Sprintf(urlFormat, orgID1.Hex(), primitive.NewObjectID().Hex(), env1, comp1.Hex())
 	req, _ = http.NewRequest("GET", fakeURL, nil)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -442,7 +442,7 @@ func TestHandler_CreateVariableOrg(t *testing.T) {
 
 	req, _ := http.NewRequest("POST", "/variables/"+orgID1.Hex(), bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -464,7 +464,7 @@ func TestHandler_CreateVariableOrg(t *testing.T) {
 
 	req, _ = http.NewRequest("POST", "/variables/"+orgID1.Hex(), bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -478,7 +478,7 @@ func TestHandler_CreateVariableOrg(t *testing.T) {
 
 	req, _ = http.NewRequest("POST", "/variables/org1", bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -497,7 +497,7 @@ func TestHandler_CreateVariableOrg(t *testing.T) {
 
 	req, _ = http.NewRequest("POST", "/variables/invalidID", bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -511,7 +511,7 @@ func TestHandler_CreateVariableOrg(t *testing.T) {
 	jsonVar, _ = json.Marshal(newVar)
 	req, _ = http.NewRequest("POST", "/variables/"+orgID1.Hex(), bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -527,7 +527,7 @@ func TestHandler_CreateVariableOrg(t *testing.T) {
 	jsonVar, _ = json.Marshal(newVar)
 	req, _ = http.NewRequest("POST", "/variables/"+orgID1.Hex(), bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -580,7 +580,7 @@ func TestHandler_CreateVariableEnv(t *testing.T) {
 	url := fmt.Sprintf(urlFormat, orgID1.Hex(), appID1.Hex(), "env1")
 	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -604,7 +604,7 @@ func TestHandler_CreateVariableEnv(t *testing.T) {
 
 	req, _ = http.NewRequest("POST", url, bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -620,7 +620,7 @@ func TestHandler_CreateVariableEnv(t *testing.T) {
 
 	req, _ = http.NewRequest("POST", url, bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -643,7 +643,7 @@ func TestHandler_CreateVariableEnv(t *testing.T) {
 	jsonVar, _ = json.Marshal(newVar)
 	req, _ = http.NewRequest("POST", url, bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -659,7 +659,7 @@ func TestHandler_CreateVariableEnv(t *testing.T) {
 	jsonVar, _ = json.Marshal(newVar)
 	req, _ = http.NewRequest("POST", url, bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -714,7 +714,7 @@ func TestHandler_CreateVariableComp(t *testing.T) {
 	url := fmt.Sprintf(urlFormat, orgID1.Hex(), appID1.Hex(), "env1", compID1.Hex())
 	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -739,7 +739,7 @@ func TestHandler_CreateVariableComp(t *testing.T) {
 
 	req, _ = http.NewRequest("POST", url, bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -756,7 +756,7 @@ func TestHandler_CreateVariableComp(t *testing.T) {
 
 	req, _ = http.NewRequest("POST", url, bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -766,7 +766,7 @@ func TestHandler_CreateVariableComp(t *testing.T) {
 
 	req, _ = http.NewRequest("POST", url, bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -786,24 +786,24 @@ func TestHandler_CreateVariableComp(t *testing.T) {
 	fakeURL := fmt.Sprintf(urlFormat, orgID1.Hex(), appID1.Hex(), "env1", "fakeComp")
 	req, _ = http.NewRequest("POST", fakeURL, bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
 	_ = json.Unmarshal(resp.Body.Bytes(), &result)
 
-	assert.Equal(t, http.StatusUnauthorized, resp.Code, "should return 401 Unauthorized")
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "should return 400 BadRequest")
 
 	fakeURL = fmt.Sprintf(urlFormat, orgID1.Hex(), "fakeApp", "env1", compID1.Hex())
 	req, _ = http.NewRequest("POST", fakeURL, bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
 	_ = json.Unmarshal(resp.Body.Bytes(), &result)
 
-	assert.Equal(t, http.StatusUnauthorized, resp.Code, "should return 401 Unauthorized")
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "should return 400 BadRequest")
 
 	newVar = Variable{
 		Name: "newVarX",
@@ -811,7 +811,7 @@ func TestHandler_CreateVariableComp(t *testing.T) {
 	jsonVar, _ = json.Marshal(newVar)
 	req, _ = http.NewRequest("POST", url, bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -827,7 +827,7 @@ func TestHandler_CreateVariableComp(t *testing.T) {
 	jsonVar, _ = json.Marshal(newVar)
 	req, _ = http.NewRequest("POST", url, bytes.NewBuffer(jsonVar))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
 
 	resp = httptest.NewRecorder()
 	router.ServeHTTP(resp, req)


### PR DESCRIPTION
Refactor the local auth method to use Cookies instead of headers.

Add new variables:
`FRONTEND_DOMAIN`: The domain where the app is running. For development is `localhost`
`COOKIE_SECURE`: Flag to indicate if the cookie is only sent over HTTPS. For development is `false`
`CORS_ORIGINS`: Set the URL where the CORS is allowed, eg for local development: `http://localhost:3001`